### PR TITLE
fix: issues/64: Graph doesn't appear if all the "y" values are equal, but "x" values are different

### DIFF
--- a/src/charts/linear/ChartPath.js
+++ b/src/charts/linear/ChartPath.js
@@ -68,8 +68,9 @@ function combineConfigs(a, b) {
 
 const parse = (data, yRange) => {
   const { greatestY, smallestY } = findYExtremes(data);
-  const minY = yRange ? yRange[0] : smallestY.y;
-  const maxY = yRange ? yRange[1] : greatestY.y;
+  const sameExtremes = smallestY.y === greatestY.y ? 1 : 0;
+  const minY = yRange ? yRange[0] : smallestY.y - sameExtremes;
+  const maxY = yRange ? yRange[1] : greatestY.y + sameExtremes;
   const smallestX = data[0];
   const greatestX = data[data.length - 1];
   return [

--- a/src/helpers/extremesHelpers.js
+++ b/src/helpers/extremesHelpers.js
@@ -10,6 +10,13 @@ export function findYExtremes(data) {
       greatestY = d;
     }
   }
+
+  if (greatestY.y === smallestY.y) {
+    const val = smallestY.y;
+    greatestY = { ...greatestY, y: val + 1 };
+    smallestY = { ...smallestY, y: val - 1 };
+  }
+
   return {
     greatestY,
     smallestY,

--- a/src/helpers/extremesHelpers.js
+++ b/src/helpers/extremesHelpers.js
@@ -10,8 +10,6 @@ export function findYExtremes(data) {
       greatestY = d;
     }
   }
-
-
   return {
     greatestY,
     smallestY,

--- a/src/helpers/extremesHelpers.js
+++ b/src/helpers/extremesHelpers.js
@@ -11,11 +11,6 @@ export function findYExtremes(data) {
     }
   }
 
-  if (greatestY.y === smallestY.y) {
-    const val = smallestY.y;
-    greatestY = { ...greatestY, y: val + 1 };
-    smallestY = { ...smallestY, y: val - 1 };
-  }
 
   return {
     greatestY,


### PR DESCRIPTION
**Problem:**
Chart was appearing above the "canvas", because both extremes were exactly the same.

**Solution:**
Setting extremes to values between Y (so 1 and -1 for value 0) solves the problem.

**Issue:**
https://github.com/rainbow-me/react-native-animated-charts/issues/64

![simulator_screenshot_FFC82071-CB30-42B9-84B8-E9411BFD9FE9](https://user-images.githubusercontent.com/48184525/147961306-4ed7ddfd-02c0-485a-a72c-d60e11b2b8ab.png)
