### PR TITLE
docs: add archive notice pointing to the library's live home

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 > [!IMPORTANT]
-> **This repository is archived.** Development moved into the [Rainbow app](https://github.com/rainbow-me/rainbow) in late 2021 and continues at [`src/react-native-animated-charts`](https://github.com/rainbow-me/rainbow/tree/develop/src/react-native-animated-charts), where the library has since migrated to TypeScript and modern Reanimated. This snapshot is frozen at the 2021 JavaScript API and receives no maintenance; the npm package `@rainbow-me/animated-charts` is likewise unmaintained.
+> **This repository is archived.** Development moved into the [Rainbow app](https://github.com/rainbow-me/rainbow) in late 2021 and continues there, vendored inside the app's source tree, where the library has since migrated to TypeScript and modern Reanimated. This snapshot is frozen at the 2021 JavaScript API and receives no maintenance; the npm package `@rainbow-me/animated-charts` is likewise unmaintained.
 
 <p align="center">
   <h1 align="center">React Native Animated Charts</h1>

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+> [!IMPORTANT]
+> **This repository is archived.** Development moved into the [Rainbow app](https://github.com/rainbow-me/rainbow) in late 2021 and continues at [`src/react-native-animated-charts`](https://github.com/rainbow-me/rainbow/tree/develop/src/react-native-animated-charts), where the library has since migrated to TypeScript and modern Reanimated. This snapshot is frozen at the 2021 JavaScript API and receives no maintenance; the npm package `@rainbow-me/animated-charts` is likewise unmaintained.
+
 <p align="center">
   <h1 align="center">React Native Animated Charts</h1>
   <h3 align="center">Set of components and helpers for building complex and beautifully animated charts.</h3>
@@ -10,8 +13,6 @@ The library was designed to create aesthetic, animated (so far only linear) char
 The main assumptions of the library were to create smooth transitions between subsequent data sets. For this reason,
 we have discovered a shortage of existing libraries related to the charts.
 The current package was created as part of the [Rainbow.me project](https://rainbow.me/) and for this reason it was not designed as a complete and comprehensive solution for displaying various types of charts. However, we will be now using more charts in the whole application, so we believe that the number of functionalities in the application will gradually grow. 
-
-Additionally, we are open to new Pull Requests. We want this library to become popular and complete thanks to community activity.
 
 It's a part of the [Rainbow.me project](https://rainbow.me/). 
 


### PR DESCRIPTION
This repository still reads as a maintained library: the README explains installation and invites contributions, and people keep finding it (new issues as recently as 2024, and the alpha npm package still gets installed). In reality development moved into the Rainbow app in late 2021, and this snapshot is frozen at the 2021 JavaScript API while the maintained code at [`src/react-native-animated-charts`](https://github.com/rainbow-me/rainbow/tree/develop/src/react-native-animated-charts) has since moved to TypeScript and modern Reanimated.

This change adds a prominent archive notice at the top of the README pointing readers to the live home, and drops the paragraph inviting community PRs. It's the first step of archiving this repository: once it merges we'll close out the open issues and PRs, deprecate `@rainbow-me/animated-charts` on npm, and archive the repo. Counterpart cleanup in the app: rainbow-me/rainbow#7688.